### PR TITLE
Fix --specified_instances filtering and harden generation/eval robustness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,12 @@
 */sas_plan_ver
 utils/__pycache__/*
 
+# generated eval artifacts + local venv + bytecode
+.venv/
+__pycache__/
+*.pyc
+plan-bench/responses/
+plan-bench/results/
 
 llm_planning_analysis/configs/mystery_blocksworld_with_mapping.yaml
 llm_planning_analysis/diversity_evaluation.py

--- a/plan-bench/response_evaluation.py
+++ b/plan-bench/response_evaluation.py
@@ -57,9 +57,15 @@ class ResponseEvaluator:
         output_dir = f"results/{self.data['domain_name']}/{self.engine}/"
         if not self.ignore_existing and os.path.exists(output_dir+f"{task_name}.json"):
             load_dir = output_dir
-        else:
-            assert os.path.exists(response_dir+f"{task_name}.json")
+        elif os.path.exists(response_dir+f"{task_name}.json"):
             load_dir = response_dir
+        else:
+            # No response file exists for this (domain, engine, task) — e.g. an
+            # engine that produced no responses for the task. Treat it as an
+            # empty, no-data cell instead of aborting the whole evaluation with a
+            # bare assert (AssertionError, rc=1), so the task loop can continue.
+            print(f"[eval] no response file for {task_name} under {response_dir}; treating as empty")
+            return {"instances": []}
         with open(load_dir+f"{task_name}.json", 'r') as file:
             structured_output = json.load(file)
         return structured_output
@@ -224,6 +230,13 @@ class ResponseEvaluator:
                     output_dict['unmet_precondition']['predicate'] = text_to_state(line.strip(), self.data)
                     precond_act_flag = False
 
+        # Guarantee 'valid' is always set. A response that omits the
+        # "plan is (in)valid" verdict would otherwise leave 'valid' unset, and
+        # evaluate_verification would raise KeyError and abort the whole
+        # verification evaluation. With a None default such a response scores
+        # correct_binary=False ("no verdict -> incorrect"); responses that do
+        # emit a verdict keep their True/False value and are graded unchanged.
+        output_dict.setdefault('valid', None)
         return output_dict
     
     def evaluate_verification(self, task_name):
@@ -254,7 +267,14 @@ class ResponseEvaluator:
                 correct_binary = False
                 correct_w_type = False
                 correct_w_expl = False
-                parsed_llm_response = self.parse_output(problem.actions, llm_response)
+                # Tolerate parser crashes on a malformed LLM response so one bad
+                # instance scores no-verdict instead of aborting the whole cell.
+                # (The ground-truth parse below stays unwrapped — a crash there
+                # is a real bug worth surfacing.)
+                try:
+                    parsed_llm_response = self.parse_output(problem.actions, llm_response)
+                except Exception:
+                    parsed_llm_response = {'valid': None}
                 parsed_ground_truth_response = self.parse_output(problem.actions, ground_truth_response)
                 instance_dict["extracted_llm_plan"] = parsed_llm_response
                 instance_dict["parsed_ground_truth_plan"] = parsed_ground_truth_response

--- a/plan-bench/response_generation.py
+++ b/plan-bench/response_generation.py
@@ -45,6 +45,11 @@ class ResponseGenerator:
         return {'model': model, 'tokenizer': tokenizer}
 
     def get_responses(self, task_name, specified_instances = [], run_till_completion=False):
+        # Snapshot to a set so the per-instance filter below doesn't mutate
+        # state. The previous `.remove()` pattern emptied the list after the
+        # last match, which flipped `if len(...) > 0` to False and let every
+        # remaining instance fall through to send_query.
+        _specified_instances_set = set(specified_instances or [])
         output_dir = f"responses/{self.data['domain_name']}/{self.engine}/"
         os.makedirs(output_dir, exist_ok=True)
         output_json = output_dir+f"{task_name}.json"
@@ -66,11 +71,9 @@ class ResponseGenerator:
                         if self.verbose:
                             print(f"Instance {instance['instance_id']} already completed")
                         continue
-                if len(specified_instances) > 0:
-                    if instance['instance_id'] not in specified_instances:
-                        continue
-                    else:
-                        specified_instances.remove(instance['instance_id'])                   
+                # Filter against the immutable snapshot (see above).
+                if _specified_instances_set and instance['instance_id'] not in _specified_instances_set:
+                    continue
                 
                 if self.verbose:
                     print(f"Sending query to LLM: Instance {instance['instance_id']}")

--- a/plan-bench/utils/__init__.py
+++ b/plan-bench/utils/__init__.py
@@ -6,7 +6,7 @@ import hashlib
 from tarski.io import PDDLReader
 from tarski.syntax.formulas import *
 
-openai.api_key = os.environ["OPENAI_API_KEY"]
+openai.api_key = os.environ.get("OPENAI_API_KEY", "")  # tolerate missing key (e.g. local-model runs)
 random.seed(10)
 
 from .llm_utils import *

--- a/plan-bench/utils/llm_utils.py
+++ b/plan-bench/utils/llm_utils.py
@@ -1,7 +1,16 @@
-from transformers import StoppingCriteriaList, StoppingCriteria
-import openai
+# Tolerant imports: let this module load when only a subset of backends is
+# installed, and when no OPENAI_API_KEY is set (e.g. when driving a local model).
 import os
-openai.api_key = os.environ["OPENAI_API_KEY"]
+try:
+    from transformers import StoppingCriteriaList, StoppingCriteria  # noqa: F401
+except ImportError:
+    StoppingCriteriaList = StoppingCriteria = None
+try:
+    import openai
+
+    openai.api_key = os.environ.get("OPENAI_API_KEY", "")
+except ImportError:
+    openai = None
 def generate_from_bloom(model, tokenizer, query, max_tokens):
     encoded_input = tokenizer(query, return_tensors='pt')
     stop = tokenizer("[PLAN END]", return_tensors='pt')
@@ -60,7 +69,7 @@ def send_query(query, engine, max_tokens, model=None, stop="[STATEMENT]"):
             max_token_err_flag = True
             print("[-]: Failed GPT3 query execution: {}".format(e))
         text_response = response['choices'][0]['message']['content'] if not max_token_err_flag else ""
-        return text_response.strip()        
+        return text_response.strip()
     else:
         try:
             response = openai.Completion.create(


### PR DESCRIPTION
## Summary

This PR fixes a correctness bug in `--specified_instances` filtering and makes the response-generation/evaluation pipeline robust enough to run with a non-OpenAI backend and to degrade gracefully on outputs that don't follow the expected template — instead of crashing the whole run.

## Bug fix: `--specified_instances` leaks unspecified instances

`ResponseGenerator.get_responses` filters with a `.remove()` inside the loop:

```python
if len(specified_instances) > 0:
    if instance['instance_id'] not in specified_instances:
        continue
    else:
        specified_instances.remove(instance['instance_id'])
```

Once the last specified id is removed the list is empty, so `len(specified_instances) > 0` becomes `False` and **every remaining instance falls through and is sent to the model** — the filter silently stops applying partway through the dataset. Fixed by snapshotting the ids into a `set` at function entry and using immutable membership tests in the loop.

## Robustness: evaluation no longer crashes on non-template / missing output

`response_evaluation.py`:

- **`load_json`** — a missing response file now yields an empty instance set instead of a bare `assert` that aborts the whole run (`AssertionError`, `rc=1`). A `(domain, engine, task)` cell with no responses is recorded as no-data and the task loop continues.
- **`parse_output`** — default `'valid'` to `None`, so a verification response that omits the `plan is (in)valid` verdict scores `correct_binary=False` instead of raising `KeyError` and crashing the entire verification evaluation. Responses that do emit a verdict are graded exactly as before.
- **`evaluate_verification`** — wrap the LLM-response parse in `try/except` so one malformed response can't crash the cell mid-loop. The ground-truth parse stays unwrapped (a crash there is a real bug worth surfacing).

These are comparability-preserving: a `None` verdict never equals ground truth, and the verdict-emission rate stays recoverable from `extracted_llm_plan['valid']`.

## Portability: import without an API key / without all backends

`utils/__init__.py`, `utils/llm_utils.py` — read `OPENAI_API_KEY` via `os.environ.get` and import `openai` / `transformers` defensively, so the modules import with no key set and without the HF deps installed (e.g. when driving a local model backend).

## Misc

`.gitignore` — ignore generated `responses/`, `results/`, local `.venv`, and Python bytecode.